### PR TITLE
Dev: switch from PHP-type commands to the WP versions.

### DIFF
--- a/php/class-jwr-plugin-options.php
+++ b/php/class-jwr-plugin-options.php
@@ -136,7 +136,6 @@ class JWR_Plugin_Options {
 			return;
 		}
 
-		// $file_contents = file_get_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json' );
 		global $wp_filesystem;
 		$file_contents = $wp_filesystem->get_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json' );
 		$json_array    = json_decode( $file_contents, true );
@@ -152,8 +151,7 @@ class JWR_Plugin_Options {
 			$json_array['fields'][] = $field;
 		}
 		$json_array['modified'] = time();
-		$json_string            = json_encode( $json_array );
-		// file_put_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json', $json_string );
+		$json_string            = wp_json_encode( $json_array );
 		$wp_filesystem->put_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json', $json_string );
 
 		\update_option( $option_prefix . $this->group_id, $this->version );

--- a/php/class-jwr-plugin-options.php
+++ b/php/class-jwr-plugin-options.php
@@ -136,7 +136,9 @@ class JWR_Plugin_Options {
 			return;
 		}
 
-		$file_contents = file_get_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json' );
+		// $file_contents = file_get_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json' );
+		global $wp_filesystem;
+		$file_contents = $wp_filesystem->get_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json' );
 		$json_array    = json_decode( $file_contents, true );
 
 		$fields = $this->group_data;
@@ -151,7 +153,8 @@ class JWR_Plugin_Options {
 		}
 		$json_array['modified'] = time();
 		$json_string            = json_encode( $json_array );
-		file_put_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json', $json_string );
+		// file_put_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json', $json_string );
+		$wp_filesystem->put_contents( __DIR__ . '/../acf-json/group_jwr_control_panel.json', $json_string );
 
 		\update_option( $option_prefix . $this->group_id, $this->version );
 	}


### PR DESCRIPTION
Tested switching from PHP-type commands to the WP versions.

Why? If I'm doing things the WordPress way, then I should follow WP guidelines.